### PR TITLE
Fix avatar cropper (GitHub-style replica) and avatar toggle data loss

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,29 @@
   /* Remove the custom .line-clamp-2 utility if using Tailwind's plugin */
 }
 
+/* GitHub-style avatar cropper (overrides for react-image-crop).
+   Edge handles are already hidden by the library for fixed-aspect crops,
+   leaving the four corner handles, as on GitHub. */
+.ReactCrop {
+  --rc-drag-handle-size: 14px;
+  --rc-drag-handle-bg-colour: #fff;
+  --rc-border-color: rgb(255 255 255 / 0.9);
+}
+
+/* Solid selection border instead of the marching-ants animation.
+   !important is needed to beat the library's higher-specificity rule. */
+.ReactCrop .ReactCrop__crop-selection {
+  animation: none !important;
+  background-image: none !important;
+  border: 1px solid rgb(255 255 255 / 0.9);
+}
+
+.ReactCrop .ReactCrop__drag-handle {
+  border: 1px solid rgb(0 0 0 / 0.4);
+  border-radius: 2px;
+  box-shadow: 0 0 3px rgb(0 0 0 / 0.5);
+}
+
 /* Add smooth scrolling */
 html {
   scroll-behavior: smooth;

--- a/components/editors/hero-editor.tsx
+++ b/components/editors/hero-editor.tsx
@@ -8,6 +8,7 @@ import { Switch } from "@/components/ui/switch"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { AvatarUpload } from "@/components/ui/avatar-upload"
 import { usePortfolioStore, type HeroContent } from "@/lib/portfolio-store"
+import { initialsFromName } from "@/lib/utils"
 
 export function HeroEditor() {
   const { content, updateHeroContent } = usePortfolioStore()
@@ -96,6 +97,7 @@ export function HeroEditor() {
             <AvatarUpload
               value={formData.avatar}
               onChange={(value) => handleAvatarChange(value)}
+              fallbackInitials={initialsFromName(formData.name)}
             />
           </div>
 

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -6,6 +6,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Github, Linkedin, Mail, Download, ArrowRight, Twitter } from "lucide-react"
 import { motion } from "framer-motion"
 import type { HeroContent } from "@/lib/portfolio-store"
+import { initialsFromName } from "@/lib/utils"
 import dynamic from "next/dynamic"
 
 // Dynamically import Lucide icons with ssr: false
@@ -42,11 +43,11 @@ export function HeroSection({ content }: HeroSectionProps) {
             className="relative mx-auto w-48 h-48 rounded-full"
           >
             <Avatar className="w-full h-full">
-              {content.avatar.imageUrl ? (
+              {content.avatar.type === "image" && content.avatar.imageUrl ? (
                 <AvatarImage src={content.avatar.imageUrl} alt={content.name} />
               ) : null}
               <AvatarFallback className="text-6xl font-bold bg-gradient-to-br from-primary to-primary/60 text-primary-foreground flex items-center justify-center">
-                {content.avatar.initials}
+                {content.avatar.initials || initialsFromName(content.name)}
               </AvatarFallback>
             </Avatar>
           </motion.div>

--- a/components/ui/avatar-upload.tsx
+++ b/components/ui/avatar-upload.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, type ChangeEvent, type SyntheticEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -15,10 +15,17 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
-import Cropper from 'react-easy-crop'
-import type { Area } from 'react-easy-crop'
+import ReactCrop, {
+  centerCrop,
+  makeAspectCrop,
+  convertToPixelCrop,
+  type Crop,
+  type PixelCrop,
+} from 'react-image-crop'
+import 'react-image-crop/dist/ReactCrop.css'
 import { Switch } from '@/components/ui/switch'
 import { useToast } from '@/hooks/use-toast'
+import { validateImageFile } from '@/lib/image-utils'
 
 interface AvatarUploadProps {
   value: {
@@ -27,110 +34,82 @@ interface AvatarUploadProps {
     initials: string
   }
   onChange: (value: { type: 'image' | 'initials'; imageUrl?: string; initials: string }) => void
+  /** Shown when no initials are set, e.g. derived from the person's name. */
+  fallbackInitials?: string
   className?: string
 }
 
 // Keep stored avatars small: plenty for a 192px display circle, and small
 // enough to embed as a data URL when no upload backend is configured.
 const OUTPUT_SIZE = 512
-const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB source file
 
-const createImage = (url: string): Promise<HTMLImageElement> =>
-  new Promise((resolve, reject) => {
-    const image = new Image()
-    image.addEventListener('load', () => resolve(image))
-    image.addEventListener('error', (error) => reject(error))
-    image.setAttribute('crossOrigin', 'anonymous')
-    image.src = url
-  })
+// GitHub-style initial selection: a centered square covering most of the photo.
+function initialCrop(width: number, height: number): Crop {
+  return centerCrop(makeAspectCrop({ unit: '%', width: 90 }, 1, width, height), width, height)
+}
 
-// Rotation-aware crop (react-easy-crop's documented recipe): draw the rotated
-// image onto a bounding-box canvas, then cut the crop area out of that.
-const getCroppedCanvas = async (
-  imageSrc: string,
-  pixelCrop: Area,
-  rotation: number,
-): Promise<HTMLCanvasElement> => {
-  const image = await createImage(imageSrc)
-  const rotRad = (rotation * Math.PI) / 180
-
-  const bBoxWidth = Math.abs(Math.cos(rotRad) * image.width) + Math.abs(Math.sin(rotRad) * image.height)
-  const bBoxHeight = Math.abs(Math.sin(rotRad) * image.width) + Math.abs(Math.cos(rotRad) * image.height)
+// Cut the selected square out of the displayed image at natural resolution,
+// on a white background so transparent PNGs don't turn black in the JPEG.
+function cropToCanvas(image: HTMLImageElement, crop: PixelCrop): HTMLCanvasElement {
+  const scaleX = image.naturalWidth / image.width
+  const scaleY = image.naturalHeight / image.height
+  const size = Math.max(1, Math.round(Math.min(OUTPUT_SIZE, crop.width * scaleX)))
 
   const canvas = document.createElement('canvas')
-  canvas.width = bBoxWidth
-  canvas.height = bBoxHeight
+  canvas.width = size
+  canvas.height = size
   const ctx = canvas.getContext('2d')
   if (!ctx) throw new Error('Canvas is not supported in this browser.')
-  ctx.translate(bBoxWidth / 2, bBoxHeight / 2)
-  ctx.rotate(rotRad)
-  ctx.translate(-image.width / 2, -image.height / 2)
-  ctx.drawImage(image, 0, 0)
-
-  const output = document.createElement('canvas')
-  const size = Math.min(OUTPUT_SIZE, pixelCrop.width)
-  output.width = size
-  output.height = size
-  const outputCtx = output.getContext('2d')
-  if (!outputCtx) throw new Error('Canvas is not supported in this browser.')
-  outputCtx.drawImage(
-    canvas,
-    pixelCrop.x,
-    pixelCrop.y,
-    pixelCrop.width,
-    pixelCrop.height,
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, size, size)
+  ctx.imageSmoothingQuality = 'high'
+  ctx.drawImage(
+    image,
+    crop.x * scaleX,
+    crop.y * scaleY,
+    crop.width * scaleX,
+    crop.height * scaleY,
     0,
     0,
     size,
     size,
   )
-  return output
+  return canvas
 }
 
 const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob | null> =>
   new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.9))
 
-export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) {
+export function AvatarUpload({ value, onChange, fallbackInitials, className }: AvatarUploadProps) {
   const [isUploading, setIsUploading] = useState(false)
   const [imageSrc, setImageSrc] = useState<string | null>(null)
-  const [crop, setCrop] = useState({ x: 0, y: 0 })
-  const [zoom, setZoom] = useState(1)
-  const [rotation, setRotation] = useState(0)
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null)
+  const [crop, setCrop] = useState<Crop>()
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
   const { toast } = useToast()
 
-  const onCropComplete = useCallback((_croppedArea: Area, croppedAreaPixels: Area) => {
-    setCroppedAreaPixels(croppedAreaPixels)
-  }, [])
-
-  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp']
-    if (!allowedTypes.includes(file.type)) {
-      toast({
-        title: 'Unsupported file type',
-        description: 'Please choose a JPG, PNG, or WebP image.',
-        variant: 'destructive',
-      })
+    const validationError = validateImageFile(file)
+    if (validationError) {
+      toast({ title: 'Could not use this image', description: validationError, variant: 'destructive' })
       return
     }
-    if (file.size > MAX_FILE_SIZE) {
-      toast({
-        title: 'File too large',
-        description: 'Please choose an image under 10MB.',
-        variant: 'destructive',
-      })
-      return
-    }
-    setCrop({ x: 0, y: 0 })
-    setZoom(1)
-    setRotation(0)
+    setCrop(undefined)
+    setCompletedCrop(undefined)
     const reader = new FileReader()
     reader.onload = () => setImageSrc(reader.result as string)
     reader.readAsDataURL(file)
+  }
+
+  const handleImageLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    const { width, height } = event.currentTarget
+    const nextCrop = initialCrop(width, height)
+    setCrop(nextCrop)
+    setCompletedCrop(convertToPixelCrop(nextCrop, width, height))
   }
 
   // Try the Supabase upload endpoint for a hosted URL; if it isn't configured
@@ -154,10 +133,11 @@ export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) 
   }
 
   const handleSaveCroppedImage = async () => {
-    if (!imageSrc || !croppedAreaPixels) return
+    const image = imgRef.current
+    if (!image || !completedCrop?.width || !completedCrop?.height) return
     setIsUploading(true)
     try {
-      const canvas = await getCroppedCanvas(imageSrc, croppedAreaPixels, rotation)
+      const canvas = cropToCanvas(image, completedCrop)
       const { url, hosted } = await uploadOrEmbed(canvas)
       onChange({
         type: 'image',
@@ -166,7 +146,7 @@ export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) 
       })
       setImageSrc(null)
       toast({
-        title: 'Avatar updated',
+        title: 'Profile picture updated',
         description: hosted
           ? 'Your photo was uploaded and added to the portfolio.'
           : 'Your photo was saved with the portfolio (no upload service configured — it is embedded directly).',
@@ -197,16 +177,17 @@ export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) 
     })
   }
 
+  // Switching display type keeps the uploaded photo, so toggling back to
+  // "image" restores it. Only the explicit Remove button deletes the photo.
   const handleTypeChange = (newType: 'image' | 'initials') => {
     onChange({
       ...value,
       type: newType,
-      // Clear imageUrl if switching to initials type
-      imageUrl: newType === 'initials' ? undefined : value.imageUrl,
     })
   }
 
   const displayUrl = value.type === 'image' ? value.imageUrl : undefined
+  const displayInitials = value.initials || fallbackInitials || '?'
 
   return (
     <div className={cn('flex flex-col items-center gap-4', className)}>
@@ -216,7 +197,7 @@ export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) 
             <AvatarImage src={displayUrl} alt="Avatar" />
           ) : null}
           <AvatarFallback className="text-2xl font-bold">
-            {value.initials}
+            {displayInitials}
           </AvatarFallback>
         </Avatar>
 
@@ -272,10 +253,15 @@ export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) 
               id="initials"
               value={value.initials}
               onChange={(e) => handleInitialsChange(e.target.value)}
-              placeholder="JD"
+              placeholder={fallbackInitials || 'JD'}
               maxLength={3}
               className="text-center uppercase"
             />
+            {!value.initials && fallbackInitials && (
+              <p className="text-xs text-muted-foreground">
+                Using &quot;{fallbackInitials}&quot; from your name — type here to override.
+              </p>
+            )}
           </div>
         )}
       </div>
@@ -289,67 +275,49 @@ export function AvatarUpload({ value, onChange, className }: AvatarUploadProps) 
       />
 
       <Dialog open={!!imageSrc} onOpenChange={(open) => !open && setImageSrc(null)}>
-        <DialogContent className="sm:max-w-[425px] h-[540px] flex flex-col p-0">
-          <DialogHeader className="p-6 pb-4">
-            <DialogTitle>Crop your photo</DialogTitle>
-            <DialogDescription>Drag to position, then adjust zoom and rotation.</DialogDescription>
+        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[480px]">
+          <DialogHeader className="border-b p-4 pr-12 text-left">
+            <DialogTitle>Crop your new profile picture</DialogTitle>
+            <DialogDescription>
+              Drag the selection to reposition it, or resize it with the corner handles.
+            </DialogDescription>
           </DialogHeader>
-          <div className="relative flex-1 bg-gray-900">
-            <Cropper
-              image={imageSrc || ''}
-              crop={crop}
-              zoom={zoom}
-              rotation={rotation}
-              aspect={1 / 1}
-              onCropChange={setCrop}
-              onZoomChange={setZoom}
-              onRotationChange={setRotation}
-              onCropComplete={onCropComplete}
-              cropShape="round"
-              showGrid={false}
-              restrictPosition={false}
-              classes={{
-                containerClassName: 'bg-transparent',
-                mediaClassName: 'object-contain',
-                cropAreaClassName: 'rounded-full border-2 border-primary',
-              }}
-            />
+
+          <div className="flex max-h-[60vh] items-center justify-center overflow-auto bg-muted/40 p-4">
+            {imageSrc && (
+              <ReactCrop
+                crop={crop}
+                onChange={(_pixelCrop, percentCrop) => setCrop(percentCrop)}
+                onComplete={(pixelCrop) => setCompletedCrop(pixelCrop)}
+                aspect={1}
+                minWidth={32}
+                keepSelection
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  ref={imgRef}
+                  src={imageSrc}
+                  alt="Photo to crop"
+                  onLoad={handleImageLoad}
+                  className="max-h-[52vh] w-auto select-none"
+                />
+              </ReactCrop>
+            )}
           </div>
-          <DialogFooter className="flex flex-col gap-4 p-6 pt-4">
-            <div className="flex items-center gap-4">
-              <Label htmlFor="zoom" className="w-16">Zoom</Label>
-              <Input
-                id="zoom"
-                type="range"
-                value={zoom}
-                min={1}
-                max={3}
-                step={0.1}
-                onChange={(e) => setZoom(Number(e.target.value))}
-                className="w-full"
-              />
-            </div>
-            <div className="flex items-center gap-4">
-              <Label htmlFor="rotation" className="w-16">Rotation</Label>
-              <Input
-                id="rotation"
-                type="range"
-                value={rotation}
-                min={0}
-                max={360}
-                step={1}
-                onChange={(e) => setRotation(Number(e.target.value))}
-                className="w-full"
-              />
-            </div>
-            <Button onClick={handleSaveCroppedImage} disabled={isUploading}>
+
+          <DialogFooter className="border-t p-4">
+            <Button
+              className="w-full"
+              onClick={handleSaveCroppedImage}
+              disabled={isUploading || !completedCrop?.width}
+            >
               {isUploading ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   Saving...
                 </>
               ) : (
-                'Save photo'
+                'Set new profile picture'
               )}
             </Button>
           </DialogFooter>

--- a/lib/__tests__/export-portfolio.test.ts
+++ b/lib/__tests__/export-portfolio.test.ts
@@ -120,6 +120,27 @@ describe("generatePortfolioHtml", () => {
     expect(html).toContain("https://example.com/cv.pdf")
   })
 
+  it("derives initials from the name when none are set", () => {
+    const noInitials = {
+      ...content,
+      hero: { ...content.hero, avatar: { type: "initials" as const, initials: "" } },
+    }
+    expect(generatePortfolioHtml(noInitials, ["hero"])).toContain(">IA</div>")
+  })
+
+  it("shows initials when the avatar type is initials, even if a photo is stored", () => {
+    const photoKept = {
+      ...content,
+      hero: {
+        ...content.hero,
+        avatar: { type: "initials" as const, initials: "IA", imageUrl: "https://example.com/me.jpg" },
+      },
+    }
+    const result = generatePortfolioHtml(photoKept, ["hero"])
+    expect(result).toContain(">IA</div>")
+    expect(result).not.toContain("https://example.com/me.jpg")
+  })
+
   it("replaces local placeholder images and keeps external ones", () => {
     expect(html).toContain("project-image-placeholder")
     expect(html).toContain("https://example.com/img.png")

--- a/lib/export-portfolio.ts
+++ b/lib/export-portfolio.ts
@@ -76,11 +76,21 @@ function projectImage(image: string, title: string): string {
   return `<img class="project-image" src="${esc(image)}" alt="${esc(title)}" loading="lazy" />`
 }
 
+function initialsFromName(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}
+
 function renderHero(hero: HeroContent, hasProjects: boolean, hasContact: boolean): string {
   const avatar =
     hero.avatar.type === "image" && hero.avatar.imageUrl
       ? `<img class="avatar" src="${esc(hero.avatar.imageUrl)}" alt="${esc(hero.name)}" />`
-      : `<div class="avatar avatar-initials">${esc(hero.avatar.initials || "")}</div>`
+      : `<div class="avatar avatar-initials">${esc(hero.avatar.initials || initialsFromName(hero.name))}</div>`
 
   const primaryTarget = hasProjects ? "#projects" : hasContact ? "#contact" : "#hero"
   const ctas: string[] = []
@@ -490,7 +500,7 @@ export function generatePortfolioHtml(content: PortfolioContent, selectedSection
 <body>
   <nav>
     <div class="container nav-inner">
-      <a class="nav-brand" href="#${sections[0] ?? "hero"}">${esc(content.hero.avatar.initials || content.hero.name)}</a>
+      <a class="nav-brand" href="#${sections[0] ?? "hero"}">${esc(content.hero.avatar.initials || initialsFromName(content.hero.name) || content.hero.name)}</a>
       <div class="nav-links" id="nav-links">
         ${navLinks}
       </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Derive avatar initials from a name, e.g. "John Doe" -> "JD". */
+export function initialsFromName(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
-    "react-easy-crop": "^5.4.2",
+    "react-image-crop": "^11.0.10",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      react-easy-crop:
-        specifier: ^5.4.2
-        version: 5.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-image-crop:
+        specifier: ^11.0.10
+        version: 11.0.10(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
@@ -2661,9 +2661,6 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
-  normalize-wheel@1.0.1:
-    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2865,11 +2862,10 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-easy-crop@5.4.2:
-    resolution: {integrity: sha512-V+GQUTkNWD8gK0mbZQfwTvcDxyCB4GS0cM36is8dAcvnsHY7DMEDP2D5IqHju55TOiCHwElJPVOYDgiu8BEiHQ==}
+  react-image-crop@11.0.10:
+    resolution: {integrity: sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==}
     peerDependencies:
-      react: '>=16.4.0'
-      react-dom: '>=16.4.0'
+      react: '>=16.13.1'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5979,8 +5975,6 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
-  normalize-wheel@1.0.1: {}
-
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -6170,12 +6164,9 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-easy-crop@5.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-image-crop@11.0.10(react@18.3.1):
     dependencies:
-      normalize-wheel: 1.0.1
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.8.1
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
## What & why

The avatar cropper was broken in two ways (both visible in screenshots):
1. The zoom/rotation sliders rendered as broken toggle-like stubs.
2. The interaction model (pan the image under a fixed circle) wasn't the GitHub cropper experience the project was aiming for.

Separately, deactivating **Use Image Avatar** permanently discarded the uploaded photo and left an empty circle.

## Changes

**GitHub-style cropper** — replaced `react-easy-crop` with `react-image-crop`:
- The photo stays still; you drag and resize a **square selection with corner handles**, everything outside dimmed — an exact-feel replica of GitHub's profile-picture cropper
- Centered initial selection (90% of the photo), corner-only white handles, solid border, keyboard-movable
- Crop drawn on a **white background** (transparent PNGs no longer turn black in the JPEG output), high-quality downscale to 512px

**Avatar state fixes:**
- Toggling the avatar type **keeps** the uploaded photo — only the explicit Remove button deletes it; toggling back restores it
- Hero section respects the selected avatar type instead of always rendering the stored image
- Empty initials now **fall back to initials derived from the name** (editor preview, hero, and exported sites)

## Verification
`pnpm lint` clean · `pnpm test` 16/16 (2 new regression tests) · `pnpm build` green

https://claude.ai/code/session_01XomBhYPpEqfK3RWDJQkAxY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XomBhYPpEqfK3RWDJQkAxY)_