### PR TITLE
Fix: initials avatar fallback after toggling off / removing image

### DIFF
--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -22,6 +22,8 @@ interface HeroSectionProps {
 }
 
 export function HeroSection({ content }: HeroSectionProps) {
+  const showAvatarImage = content.avatar.type === "image" && Boolean(content.avatar.imageUrl)
+
   return (
     <section
       id="hero"
@@ -42,8 +44,11 @@ export function HeroSection({ content }: HeroSectionProps) {
             transition={{ delay: 0.2, duration: 0.6 }}
             className="relative mx-auto w-48 h-48 rounded-full"
           >
-            <Avatar className="w-full h-full">
-              {content.avatar.type === "image" && content.avatar.imageUrl ? (
+            <Avatar
+              key={showAvatarImage ? content.avatar.imageUrl : 'initials'}
+              className="w-full h-full"
+            >
+              {showAvatarImage ? (
                 <AvatarImage src={content.avatar.imageUrl} alt={content.name} />
               ) : null}
               <AvatarFallback className="text-6xl font-bold bg-gradient-to-br from-primary to-primary/60 text-primary-foreground flex items-center justify-center">

--- a/components/ui/avatar-upload.tsx
+++ b/components/ui/avatar-upload.tsx
@@ -192,7 +192,10 @@ export function AvatarUpload({ value, onChange, fallbackInitials, className }: A
   return (
     <div className={cn('flex flex-col items-center gap-4', className)}>
       <div className="relative">
-        <Avatar className="w-32 h-32">
+        {/* key forces a remount when switching between image and initials so
+            Radix's avatar loading status resets — otherwise the fallback stays
+            hidden (blank circle) after an image is removed. */}
+        <Avatar key={displayUrl ?? 'initials'} className="w-32 h-32">
           {displayUrl ? (
             <AvatarImage src={displayUrl} alt="Avatar" />
           ) : null}


### PR DESCRIPTION
## The bug

Turning off **Use Image Avatar** (or clicking **Remove**) left a **blank circle** instead of falling back to the initials avatar. My previous PR fixed the *data* (the photo is no longer deleted), but the *display* still broke.

## Root cause

A Radix Avatar quirk, not our fallback logic. Once an `AvatarImage` mounts and loads, the Avatar root stores `imageLoadingStatus: "loaded"`. Removing the `AvatarImage` from the tree **never resets that status**, so `AvatarFallback` — which only renders when the status isn't `"loaded"` — stays hidden. That's why a fresh load shows "JD" fine, but it goes blank *after* an image has been shown.

## Fix

Key the `Avatar` on image-vs-initials in both places that render it (the editor preview and the hero section). Switching states changes the key, React remounts the Avatar with a clean loading status, and the initials fallback renders reliably.

Traced against the reproduction:
- Toggle off → `key` → `'initials'` → remount → initials show ✓
- Remove image → same path → initials show ✓
- Toggle back on → `key` → image URL → remount → photo shows ✓

## Verification
`pnpm lint` clean · `pnpm test` 16/16 · `pnpm build` green

Note: as before, I can't drive a real browser in this environment (headless-browser downloads are blocked), so this is verified by root-cause analysis + build/lint/tests rather than a live click-through.

https://claude.ai/code/session_01XomBhYPpEqfK3RWDJQkAxY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XomBhYPpEqfK3RWDJQkAxY)_